### PR TITLE
Fix "Could not find lint-gradle-api.jar (26.2.1)"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,8 +14,8 @@ def DEFAULT_TARGET_SDK_VERSION  = 26
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.1'


### PR DESCRIPTION
Necessary changes order of the repositories to fix error:

![screenshot from 2018-11-22 16-18-32](https://user-images.githubusercontent.com/12402128/48918524-51c0b180-ee74-11e8-97d4-16e6de7c288b.png)

