### PR TITLE
upgrade to not use imageLoader

### DIFF
--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -6,7 +6,10 @@
 #import <React/RCTImageSource.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
-#import <React/RCTImageLoader.h>
+#import "RCTImageURLLoader.h"
+#import "RCTImageShadowView.h"
+#import "RCTImageView.h"
+#import "RCTImageLoaderProtocol.h"
 
 @interface RNPhotoView()
 
@@ -338,7 +341,7 @@
         }
 
         // use default values from [imageLoader loadImageWithURLRequest:request callback:callback] method
-        [_bridge.imageLoader loadImageWithURLRequest:request
+        [[_bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:request
                                         size:CGSizeZero
                                        scale:1
                                      clipped:YES


### PR DESCRIPTION
ImageLoader is removed in rn 0.61, so this library doesn't work due the error: `RCTImageLoader.h file not found`

This change is inspired by this comment: https://github.com/react-native-community/react-native-svg/issues/1141#issuecomment-540940897