### PR TITLE
BUGFIX: Update Android to use AndroidX Annotation Libraries

### DIFF
--- a/android/src/main/java/io/amarcruz/photoview/ImageEvent.java
+++ b/android/src/main/java/io/amarcruz/photoview/ImageEvent.java
@@ -1,6 +1,6 @@
 package io.amarcruz.photoview;
 
-import android.support.annotation.IntDef;
+import androidx.annotation.IntDef;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;

--- a/android/src/main/java/io/amarcruz/photoview/PhotoView.java
+++ b/android/src/main/java/io/amarcruz/photoview/PhotoView.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.drawee.backends.pipeline.PipelineDraweeControllerBuilder;
 import com.facebook.drawee.controller.BaseControllerListener;
@@ -26,7 +26,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import me.relex.photodraweeview.PhotoDraweeView;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.egl.EGLContext;

--- a/android/src/main/java/io/amarcruz/photoview/PhotoViewManager.java
+++ b/android/src/main/java/io/amarcruz/photoview/PhotoViewManager.java
@@ -11,8 +11,8 @@ import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import androidx.annotation.Nonnull;
+import androidx.annotation.Nullable;
 import java.util.Map;
 
 /**

--- a/android/src/main/java/io/amarcruz/photoview/PhotoViewPackage.java
+++ b/android/src/main/java/io/amarcruz/photoview/PhotoViewPackage.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nonnull;
+import androidx.annotation.Nonnull;
 
 /**
  * @author alwx (https://github.com/alwx)

--- a/android/src/main/java/io/amarcruz/photoview/ResourceDrawableIdHelper.java
+++ b/android/src/main/java/io/amarcruz/photoview/ResourceDrawableIdHelper.java
@@ -1,6 +1,6 @@
 package io.amarcruz.photoview;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -6,7 +6,10 @@
 #import <React/RCTImageSource.h>
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
-#import <React/RCTImageLoader.h>
+#import "RCTImageURLLoader.h"
+#import "RCTImageShadowView.h"
+#import "RCTImageView.h"
+#import "RCTImageLoaderProtocol.h"
 
 @interface RNPhotoView()
 
@@ -338,7 +341,7 @@
         }
 
         // use default values from [imageLoader loadImageWithURLRequest:request callback:callback] method
-        [_bridge.imageLoader loadImageWithURLRequest:request
+        [[_bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:request
                                         size:CGSizeZero
                                        scale:1
                                      clipped:YES


### PR DESCRIPTION
Currently for this package to work, Jetify must run to convert these old support libraries.
This updates Android libraries to use the newer AndroidX annotation libraries and no longer requires Jetify.